### PR TITLE
fix: podcaster provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { RouterProvider } from 'react-router-dom'
 import { ROUTER_APP } from 'src/routes/router'
+import { PodcasterProvider } from './context/context'
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -16,10 +17,12 @@ export const queryClient = new QueryClient({
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={ROUTER_APP} />
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    <PodcasterProvider>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={ROUTER_APP} />
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </PodcasterProvider>
   )
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,9 @@ import { StrictMode } from 'react'
 import ReactDOM from 'react-dom/client'
 import App from 'src/App.tsx'
 import 'src/index.css'
-import { PodcasterProvider } from './context/context'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>
-    <PodcasterProvider>
-      <App />
-    </PodcasterProvider>
+    <App />
   </StrictMode>
 )


### PR DESCRIPTION
Move the podcaster provider to the app component. This fixes the tests that are failing, so you don't have to create a custom render for the tests.